### PR TITLE
Fix setup errors and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .idea/
 */.DS_Store
+*.pyc
+events.*
+lightning_logs

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Installation
   ```
   git clone https://github.com/Ghostish/Open3DSOT.git
   cd Open3DSOT
-  conda create -n Open3DSOT  python=3.6
+  conda create -n Open3DSOT  python=3.8
   conda activate Open3DSOT
   ```
 + Install pytorch

--- a/datasets/nuscenes_data.py
+++ b/datasets/nuscenes_data.py
@@ -5,11 +5,15 @@ Created by zenn at 2021/9/1 15:05
 import os
 
 import numpy as np
-import nuscenes
 import pickle
-from nuscenes.nuscenes import NuScenes
-from nuscenes.utils.data_classes import LidarPointCloud, Box
-from nuscenes.utils.splits import create_splits_scenes
+try:
+    import nuscenes
+    from nuscenes.nuscenes import NuScenes
+    from nuscenes.utils.data_classes import LidarPointCloud, Box
+    from nuscenes.utils.splits import create_splits_scenes
+except ModuleNotFoundError:
+    print("Nuscenes utils are not installed")
+
 from pyquaternion import Quaternion
 
 from datasets import points_utils, base_dataset

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,7 +1,8 @@
+protobuf==3.19
 easydict==1.9
-numpy
+numpy==1.22
 pandas==1.1.5
-git+git://github.com/erikwijmans/Pointnet2_PyTorch.git#egg=pointnet2_ops&subdirectory=pointnet2_ops_lib
+git+https://github.com/erikwijmans/Pointnet2_PyTorch.git#egg=pointnet2_ops&subdirectory=pointnet2_ops_lib
 pomegranate
 pyquaternion==0.9.9
 pytorch-lightning==1.3.8


### PR DESCRIPTION
Pomegranate depends on `numpy==1.22+` to work correctly, and it means `Python 3.8` should be installed.
Pointnet2 dependency changed to `git+https` due to GitHub security update.
Nuscenes utils are not needed for KITTI testing and are made optional.
Protobuf dependency set to avoid tensorboard errors.